### PR TITLE
fix: dark mode header + Vercel serverless deployment

### DIFF
--- a/apps/server/api/index.ts
+++ b/apps/server/api/index.ts
@@ -1,0 +1,29 @@
+import { NestFactory } from '@nestjs/core';
+import { ExpressAdapter } from '@nestjs/platform-express';
+import express, { Request, Response } from 'express';
+import { AppModule } from '../src/app.module';
+
+const server = express();
+
+let app: any;
+
+async function bootstrap() {
+  if (app) return app;
+  app = await NestFactory.create(AppModule, new ExpressAdapter(server), {
+    logger: ['error', 'warn'],
+  });
+  app.setGlobalPrefix('api');
+  app.enableCors({
+    origin: true,
+    credentials: true,
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
+  });
+  await app.init();
+  return app;
+}
+
+export default async function handler(req: Request, res: Response) {
+  await bootstrap();
+  server(req, res);
+}

--- a/apps/server/tsconfig.api.json
+++ b/apps/server/tsconfig.api.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist-api",
+    "baseUrl": "./src"
+  },
+  "include": ["api/**/*.ts", "src/**/*.ts", "prisma/*.ts"]
+}

--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -1,0 +1,19 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "api/index.ts",
+      "use": "@vercel/node",
+      "config": {
+        "includeFiles": ["src/**", "prisma/**", "node_modules/.prisma/**"],
+        "tsconfig": "tsconfig.api.json"
+      }
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "api/index.ts"
+    }
+  ]
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -33,8 +33,15 @@ export const metadata: Metadata = {
   description: branding.store.description,
 };
 
+function resolveApiUrl(url: string | undefined): string {
+  const base = url || "http://localhost:5001";
+  // Ensure the URL has a protocol so Axios treats it as absolute
+  if (/^https?:\/\//.test(base)) return base;
+  return `https://${base}`;
+}
+
 const apiConfig = {
-  baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:5001",
+  baseURL: resolveApiUrl(process.env.NEXT_PUBLIC_API_URL),
 };
 
 export default function RootLayout({

--- a/packages/design-system/src/components/Atoms/Button/Button.tsx
+++ b/packages/design-system/src/components/Atoms/Button/Button.tsx
@@ -8,8 +8,8 @@ const button = tv({
     variant: {
       solid: 'bg-primary-600 text-white hover:bg-primary-700 focus-visible:ring-primary-600',
       outline:
-        'border border-gray-300 bg-transparent hover:bg-gray-50 focus-visible:ring-gray-300',
-      ghost: 'bg-transparent hover:bg-gray-100 focus-visible:ring-gray-300',
+        'border border-gray-300 bg-transparent text-gray-700 hover:bg-gray-50 focus-visible:ring-gray-300 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700',
+      ghost: 'bg-transparent text-gray-700 hover:bg-gray-100 focus-visible:ring-gray-300 dark:text-gray-200 dark:hover:bg-gray-700',
     },
     size: {
       sm: 'px-3 py-1.5 text-sm',

--- a/packages/design-system/src/components/Atoms/Input/Input.tsx
+++ b/packages/design-system/src/components/Atoms/Input/Input.tsx
@@ -6,8 +6,8 @@ const input = tv({
   base: 'w-full rounded-md transition-all focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:opacity-50',
   variants: {
     variant: {
-      outline: 'border border-gray-300 bg-white hover:border-gray-400 focus:border-primary-500 focus:ring-primary-500',
-      filled: 'border border-transparent bg-gray-100 hover:bg-gray-200 focus:bg-white focus:border-primary-500 focus:ring-primary-500',
+      outline: 'border border-gray-300 bg-white text-gray-900 placeholder:text-gray-400 hover:border-gray-400 focus:border-primary-500 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500 dark:hover:border-gray-500',
+      filled: 'border border-transparent bg-gray-100 text-gray-900 placeholder:text-gray-400 hover:bg-gray-200 focus:bg-white focus:border-primary-500 focus:ring-primary-500 dark:bg-gray-700 dark:text-gray-100 dark:placeholder:text-gray-500 dark:hover:bg-gray-600 dark:focus:bg-gray-800',
     },
     size: {
       sm: 'px-2 py-1.5 text-sm',

--- a/packages/design-system/src/components/Atoms/Text/Text.tsx
+++ b/packages/design-system/src/components/Atoms/Text/Text.tsx
@@ -25,9 +25,9 @@ const text = tv({
       right: 'text-right',
     },
     color: {
-      primary: 'text-gray-900',
-      secondary: 'text-gray-600',
-      tertiary: 'text-gray-500',
+      primary: 'text-gray-900 dark:text-gray-100',
+      secondary: 'text-gray-600 dark:text-gray-400',
+      tertiary: 'text-gray-500 dark:text-gray-500',
       error: 'text-error-500',
       success: 'text-success-500',
       warning: 'text-warning-500',

--- a/packages/design-system/src/components/Layout/CartIcon/CartIcon.tsx
+++ b/packages/design-system/src/components/Layout/CartIcon/CartIcon.tsx
@@ -4,7 +4,7 @@ import type { CartIconProps } from "./types";
 export function CartIcon({ itemCount = 0, LinkComponent }: CartIconProps) {
   return (
     <LinkComponent href="/cart" className="relative">
-      <div className="p-2 hover:bg-gray-100 rounded-lg transition-colors">
+      <div className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors text-gray-700 dark:text-gray-200">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           fill="none"

--- a/packages/design-system/src/components/Layout/Navigation/Navigation.tsx
+++ b/packages/design-system/src/components/Layout/Navigation/Navigation.tsx
@@ -16,7 +16,7 @@ export function Navigation({ links, currentPath, LinkComponent }: NavigationProp
             href={link.href}
             className={cn(
               "transition-colors relative pb-1",
-              isActive ? "text-primary-600" : "text-gray-700 hover:text-primary-600"
+              isActive ? "text-primary-600" : "text-gray-700 dark:text-gray-200 hover:text-primary-600 dark:hover:text-primary-400"
             )}
           >
             <Text size="md" weight="medium">

--- a/packages/design-system/src/components/Layout/UserMenu/UserMenu.tsx
+++ b/packages/design-system/src/components/Layout/UserMenu/UserMenu.tsx
@@ -31,7 +31,7 @@ export function UserMenu({
     <div className="relative" ref={menuRef}>
       <button
         onClick={onToggle}
-        className="flex items-center gap-2 p-2 hover:bg-gray-100 rounded-lg transition-colors"
+        className="flex items-center gap-2 p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
       >
         <div className="w-8 h-8 bg-primary-600 rounded-full flex items-center justify-center">
           <span className="text-white font-medium text-sm">
@@ -56,12 +56,12 @@ export function UserMenu({
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 mt-2 w-56 bg-white rounded-lg shadow-lg border border-gray-200 py-2 z-50">
-          <div className="px-4 py-3 border-b border-gray-200">
-            <Text size="sm" weight="medium" className="text-gray-900">
+        <div className="absolute right-0 mt-2 w-56 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-2 z-50">
+          <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+            <Text size="sm" weight="medium" className="text-gray-900 dark:text-gray-100">
               {user.firstName || ""} {user.lastName || ""}
             </Text>
-            <Text size="xs" className="text-gray-500">
+            <Text size="xs" className="text-gray-500 dark:text-gray-400">
               {user.email}
             </Text>
           </div>
@@ -69,34 +69,34 @@ export function UserMenu({
           <Stack className="py-2">
             <LinkComponent
               href="/account"
-              className="px-4 py-2 hover:bg-gray-50 transition-colors"
+              className="px-4 py-2 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
               onClick={onClose}
             >
               <Text size="sm">My Account</Text>
             </LinkComponent>
             <LinkComponent
               href="/account/orders"
-              className="px-4 py-2 hover:bg-gray-50 transition-colors"
+              className="px-4 py-2 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
               onClick={onClose}
             >
               <Text size="sm">My Orders</Text>
             </LinkComponent>
             <LinkComponent
               href="/cart"
-              className="px-4 py-2 hover:bg-gray-50 transition-colors"
+              className="px-4 py-2 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
               onClick={onClose}
             >
               <Text size="sm">Cart</Text>
             </LinkComponent>
           </Stack>
 
-          <div className="border-t border-gray-200 pt-2">
+          <div className="border-t border-gray-200 dark:border-gray-700 pt-2">
             <button
               onClick={() => {
                 onClose();
                 onLogout?.();
               }}
-              className="w-full px-4 py-2 text-left hover:bg-gray-50 transition-colors"
+              className="w-full px-4 py-2 text-left hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
             >
               <Text size="sm" className="text-red-600">
                 Sign Out


### PR DESCRIPTION
## Description

Three fixes that landed after PR #122 was merged.

## Changes

### 🎨 Dark mode — header and core components
All DS components now render correctly in dark mode:
- **Navigation**: `text-gray-700` was invisible on dark header → `dark:text-gray-200`
- **Input / SearchBar**: `bg-white` was blinding white → `dark:bg-gray-800 dark:text-gray-100`
- **Button** outline/ghost: no contrast → `dark:text-gray-200 dark:hover:bg-gray-700`
- **UserMenu** dropdown: white panel on dark → `dark:bg-gray-800` + borders/hovers
- **CartIcon**: hover and icon color → `dark:hover:bg-gray-700 dark:text-gray-200`
- **Text** component: `primary/secondary` colors now adapt → `dark:text-gray-100 / dark:text-gray-400`

### 🌐 Vercel serverless adapter (NestJS)
NestJS requires an Express adapter to run as Vercel Serverless Functions:
- `apps/server/api/index.ts` — creates the NestJS app with `ExpressAdapter`, cached between invocations, explicit CORS config
- `apps/server/vercel.json` — routes all requests to `api/index.ts`, includes Prisma files in bundle
- `apps/server/tsconfig.api.json` — TypeScript config for the serverless entry point

### 🔗 API URL fix
`NEXT_PUBLIC_API_URL` set without `https://` was treated as a relative path by Axios, resulting in the API URL being concatenated with the Vercel origin. Added a `resolveApiUrl()` guard that auto-prepends `https://` when the protocol is missing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] `pnpm lint` passes
- [x] TypeScript passes across all packages