### PR TITLE
fix: dark mode, Vercel serverless adapter, CORS headers

### DIFF
--- a/apps/server/vercel.json
+++ b/apps/server/vercel.json
@@ -13,7 +13,24 @@
   "routes": [
     {
       "src": "/(.*)",
-      "dest": "api/index.ts"
+      "methods": ["OPTIONS"],
+      "headers": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET,POST,PUT,DELETE,PATCH,OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type,Authorization",
+        "Access-Control-Max-Age": "86400"
+      },
+      "status": 204,
+      "continue": false
+    },
+    {
+      "src": "/(.*)",
+      "dest": "api/index.ts",
+      "headers": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET,POST,PUT,DELETE,PATCH,OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type,Authorization"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Description

Three post-merge fixes: full dark mode coverage in the design system, NestJS serverless adapter for Vercel, and CORS headers at the infrastructure level.

## Changes

### 🎨 Dark mode — header and core components
- **Navigation**: text invisible on dark header → `dark:text-gray-200`
- **Input / SearchBar**: white background in dark → `dark:bg-gray-800 dark:text-gray-100`
- **Button** outline/ghost: no contrast → `dark:text-gray-200 dark:hover:bg-gray-700`
- **UserMenu** dropdown: white panel on dark → `dark:bg-gray-800` + borders/hovers
- **CartIcon**: icon and hover → `dark:hover:bg-gray-700 dark:text-gray-200`
- **Text** component: `primary/secondary` colors adapt → `dark:text-gray-100 / dark:text-gray-400`

### 🌐 Vercel serverless adapter (NestJS)
NestJS requires an Express adapter to run as Vercel Serverless Functions:
- `apps/server/api/index.ts` — NestJS app with `ExpressAdapter`, cached between invocations
- `apps/server/vercel.json` — routes all requests to handler; CORS headers at infrastructure level (OPTIONS preflight + all responses)
- `apps/server/tsconfig.api.json` — TypeScript config for the serverless entry point

CORS headers are set at the **Vercel routing layer** so they are present even on 500 responses.

### 🔗 API URL fix
`NEXT_PUBLIC_API_URL` set without `https://` was treated as a relative path by Axios. Added `resolveApiUrl()` guard that auto-prepends `https://`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] `pnpm lint` passes
- [x] TypeScript passes across all packages