### PR TITLE
fix(server): parse DATABASE_URL to avoid pg misreading Supabase username

### DIFF
--- a/apps/server/src/prisma/prisma.service.ts
+++ b/apps/server/src/prisma/prisma.service.ts
@@ -3,21 +3,46 @@ import { PrismaClient } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { Pool } from 'pg';
 
+function buildPool(): Pool {
+  const connectionString = process.env.DATABASE_URL || process.env.POSTGRES_URL;
+
+  if (!connectionString) {
+    throw new Error('DATABASE_URL environment variable is not set');
+  }
+
+  // Parse the URL manually so pg never misinterprets usernames with dots
+  // (e.g. postgres.PROJECT_REF in Supabase transaction pooler)
+  try {
+    const url = new URL(connectionString);
+    return new Pool({
+      user: decodeURIComponent(url.username),
+      password: decodeURIComponent(url.password),
+      host: url.hostname,
+      port: parseInt(url.port || '5432', 10),
+      database: url.pathname.replace(/^\//, ''),
+      ssl: { rejectUnauthorized: false },
+      max: 2,
+      idleTimeoutMillis: 10_000,
+      connectionTimeoutMillis: 10_000,
+    });
+  } catch {
+    // Fallback: pass the string directly if URL parsing fails
+    return new Pool({
+      connectionString,
+      ssl: { rejectUnauthorized: false },
+      max: 2,
+      idleTimeoutMillis: 10_000,
+      connectionTimeoutMillis: 10_000,
+    });
+  }
+}
+
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
   private pool: Pool;
 
   constructor() {
-    const connectionString = process.env.DATABASE_URL || process.env.POSTGRES_URL;
-
-    const pool = new Pool({
-      connectionString,
-      // Keep pool small for serverless — avoids exhausting Supabase free tier connection limit
-      max: 2,
-      idleTimeoutMillis: 10_000,
-      connectionTimeoutMillis: 10_000,
-    });
-
+    const pool = buildPool();
     const adapter = new PrismaPg(pool);
     super({ adapter });
     this.pool = pool;
@@ -34,11 +59,9 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
 
   async cleanDatabase() {
     if (process.env.NODE_ENV === 'production') return;
-
     const models = Reflect.ownKeys(this).filter(
       (key) => key[0] !== '_' && key !== 'constructor'
     );
-
     return Promise.all(models.map((modelKey) => (this as any)[modelKey].deleteMany()));
   }
 }


### PR DESCRIPTION
## Description

The `pg` library sometimes misparses connection strings where the **username contains dots** (e.g. `postgres.zzflywojxagaaqltldmu` in Supabase's transaction pooler). Instead of passing the raw connection string, we now parse it using the WHATWG `URL` API and pass individual parameters (`user`, `password`, `host`, `port`, `database`) directly to `pg.Pool`.

This avoids ambiguous URL parsing and ensures Supabase's `postgres.PROJECT_REF` username is correctly identified as the user, not confused with a hostname.

Also adds `ssl: { rejectUnauthorized: false }` which is required for Supabase connections over TLS.

## Type of change

- [x] Bug fix (non-breaking)