### PR TITLE
fix(server): seed uses DIRECT_URL to bypass PgBouncer

### DIFF
--- a/apps/server/prisma/seed.ts
+++ b/apps/server/prisma/seed.ts
@@ -4,9 +4,15 @@ import { Pool } from 'pg';
 import * as bcrypt from 'bcrypt';
 
 // Create PostgreSQL connection pool
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL || process.env.POSTGRES_URL || 'postgresql://postgres:postgres@localhost:5432/ecommerce?schema=public',
-});
+// Prefer DIRECT_URL (bypasses PgBouncer) for seed operations,
+// fall back to DATABASE_URL for local dev where there's no DIRECT_URL.
+const connectionString =
+  process.env.DIRECT_URL ||
+  process.env.DATABASE_URL ||
+  process.env.POSTGRES_URL ||
+  'postgresql://postgres:postgres@localhost:5432/react_ecommerce';
+
+const pool = new Pool({ connectionString, ssl: { rejectUnauthorized: false } });
 
 // Create Prisma adapter
 const adapter = new PrismaPg(pool);


### PR DESCRIPTION
## Description

The seed was using `DATABASE_URL` (local Docker or PgBouncer pooler) instead of `DIRECT_URL` (direct Supabase connection). This caused the seed to populate the local database instead of Supabase.

## Fix

Seed now prefers `DIRECT_URL` → `DATABASE_URL` → `POSTGRES_URL` → localhost fallback.

`DIRECT_URL` points to the direct Supabase connection (port 5432, bypasses PgBouncer), which is the correct connection to use for DDL operations and data seeding.

Also adds `ssl: { rejectUnauthorized: false }` to support Supabase TLS.

## Type of change

- [x] Bug fix