### PR TITLE
fix(sdk): skip useCart request for unauthenticated users

### DIFF
--- a/apps/web/app/(admin)/admin/orders/[id]/page.tsx
+++ b/apps/web/app/(admin)/admin/orders/[id]/page.tsx
@@ -1,9 +1,10 @@
 import { AdminOrderDetailScreen } from "@/app/modules/admin/screens";
 
 interface Props {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
-export default function AdminOrderDetailPage({ params }: Props) {
-  return <AdminOrderDetailScreen orderId={params.id} />;
+export default async function AdminOrderDetailPage({ params }: Props) {
+  const { id } = await params;
+  return <AdminOrderDetailScreen orderId={id} />;
 }

--- a/apps/web/app/(main)/products/[id]/page.tsx
+++ b/apps/web/app/(main)/products/[id]/page.tsx
@@ -1,9 +1,10 @@
 import { ProductDetailScreen } from "@/app/modules/products/screens";
 
 interface ProductDetailPageProps {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
-export default function ProductDetailPage({ params }: ProductDetailPageProps) {
-  return <ProductDetailScreen productId={params.id} />;
+export default async function ProductDetailPage({ params }: ProductDetailPageProps) {
+  const { id } = await params;
+  return <ProductDetailScreen productId={id} />;
 }

--- a/packages/sdk/src/services/queries/useCart.ts
+++ b/packages/sdk/src/services/queries/useCart.ts
@@ -3,10 +3,16 @@ import { useApiClient } from '../../providers/ApiProvider';
 import type { Cart } from '../../entities';
 
 /**
- * Hook to get the current user's cart
+ * Hook to get the current user's cart.
+ * Only fetches when the user has an access token (authenticated).
  */
 export function useCart() {
   const { client } = useApiClient();
+
+  // Avoid firing the authenticated /api/cart request for guest users
+  const hasToken = typeof window !== 'undefined'
+    ? !!localStorage.getItem('accessToken')
+    : false;
 
   return useQuery({
     queryKey: ['cart'],
@@ -14,6 +20,7 @@ export function useCart() {
       const response = await client.get<Cart>('/api/cart');
       return response.data;
     },
+    enabled: hasToken,
   });
 }
 


### PR DESCRIPTION
## Description

`useCart()` was firing `GET /api/cart` for every user — including guests — resulting in unnecessary 401 requests on every page load. Added `enabled: hasToken` so the query only runs when an access token is present in localStorage.

Guest users see the local cart (GuestCartProvider) and the server cart is only fetched when logged in.

## Type of change

- [x] Bug fix